### PR TITLE
Corrected population frequency from gnomADe to gnomADg

### DIFF
--- a/conf/json/homo_sapiens_gca009914755v4_vcf.json
+++ b/conf/json/homo_sapiens_gca009914755v4_vcf.json
@@ -10,51 +10,58 @@
       "use_seq_region_synonyms": 0,
       "use_vcf_consequences": 1,
       "filename_template" : "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca009914755v4/T2T-CHM13v2.0/variation/Homo_sapiens-GCA_009914755.4-2022_08-gnomad.vcf.gz",
-      "population_prefix": "gnomADe:",
+      "population_prefix": "gnomADg:",
       "population_display_group": {
-        "display_group_name": "gnomAD exomes r3.1.2",
-        "display_group_priority": 1.4
+        "display_group_name": "gnomAD genomes v3.1.2",
+        "display_group_priority": 1.6
       },
       "populations": {
-        "9900010": {
-          "name": "gnomADe:ALL",
+        "9900028": {
+          "name": "gnomADg:ALL",
           "_raw_name": "",
-          "description": "All gnomAD exomes individuals"
+          "description": "All gnomAD genomes individuals"
         },
-        "9900011": {
+        "9900029": {
           "name": "afr",
           "description": "African/African American"
         },
-        "9900012": {
-          "name": "amr",
-          "description": "Latino"
+        "9900030": {
+          "name": "ami",
+          "description": "Amish"
         },
-        "9900013": {
+        "9900031": {
+          "name": "amr",
+          "description": "Latino/Admixed American"
+        },
+        "9900032": {
           "name": "asj",
           "description": "Ashkenazi Jewish"
         },
-        "9900014": {
+        "9900033": {
           "name": "eas",
           "description": "East Asian"
         },
-        "9900015": {
+        "9900034": {
           "name": "fin",
           "description": "Finnish"
         },
-        "9900016": {
+        "9900035": {
           "name": "nfe",
           "description": "Non-Finnish European"
         },
-        "9900017": {
+        "9900036": {
+          "name": "sas",
+          "description": "South Asian"
+        },
+        "9900037": {
           "name": "oth",
           "description": "Other"
         },
-        "9900018": {
-          "name": "sas",
-          "description": "South Asian"
+        "9900038": {
+          "name": "mid",
+          "description": "Middle Eastern"
         }
-      }
-
+      } 
     },
     {
       "id": "ClinVar",


### PR DESCRIPTION
The population frequency currently points to gnomADe variant set. This PR corrects it to point to gnomADg variant set
The example variant works even with the change
Sandbox link:  http://wp-np2-25.ebi.ac.uk:6080/Homo_sapiens_GCA_009914755.4/Variation/Population?db=core;r=13:107437345-107437445;v=rs1805388;vdb=variation;vf=13:107437345:G_A:gnomADg