### PR TITLE
Added config files for RR39

### DIFF
--- a/conf/ini-files/homo_sapiens_gca018466835v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018466835v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018466845v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018466845v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018466855v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018466855v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018466985v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018466985v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018467005v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018467005v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018467015v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018467015v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018467155v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018467155v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018467165v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018467165v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469405v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469405v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469415v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469415v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469425v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469425v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469665v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469665v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469675v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469675v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469685v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469685v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469695v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469695v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469705v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469705v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469865v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469865v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469875v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469875v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469925v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469925v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469935v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469935v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469945v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469945v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469955v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469955v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018469965v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018469965v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018470425v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018470425v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018470435v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018470435v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018470445v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018470445v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018470455v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018470455v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018470465v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018470465v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018471065v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018471065v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018471075v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018471075v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018471085v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018471085v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018471095v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018471095v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018471105v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018471105v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018471345v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018471345v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018471515v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018471515v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018471525v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018471525v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018471535v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018471535v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018471545v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018471545v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018471555v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018471555v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472565v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472565v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472575v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472575v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472585v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472585v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472595v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472595v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472605v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472605v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472685v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472685v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472695v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472695v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472705v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472705v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472715v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472715v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472725v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472725v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472765v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472765v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472825v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472825v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472835v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472835v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472845v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472845v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472855v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472855v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018472865v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018472865v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018473295v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018473295v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018473305v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018473305v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018473315v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018473315v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018503245v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018503245v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018503255v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018503255v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018503285v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018503285v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018503525v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018503525v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018503575v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018503575v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018503585v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018503585v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504045v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504045v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504055v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504055v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504065v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504065v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504075v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504075v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504085v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504085v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504365v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504365v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504375v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504375v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504625v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504625v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504635v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504635v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504645v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504645v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504655v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504655v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018504665v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018504665v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018505825v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018505825v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018505835v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018505835v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018505845v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018505845v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018505855v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018505855v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018505865v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018505865v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018506125v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018506125v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018506155v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018506155v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018506165v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018506165v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018506955v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018506955v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018506975v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018506975v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018852585v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018852585v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/ini-files/homo_sapiens_gca018852595v1.ini
+++ b/conf/ini-files/homo_sapiens_gca018852595v1.ini
@@ -47,26 +47,11 @@ SPECIES_RELEASE_VERSION = 1
 ####################
 
 [ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-
+CLIN_SIG = http://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/
+CLINVAR = http://www.ncbi.nlm.nih.gov/clinvar/variation/###ID###
+CLINVAR_DBSNP = http://www.ncbi.nlm.nih.gov/clinvar/?term=###ID###
 [ENSEMBL_DICTIONARY]
 
 [ENSEMBL_DICTIONARY]
 
 [SAMPLE_DATA]
-
-LOCATION_PARAM    = 
-LOCATION_TEXT     = 
-
-GENE_PARAM        = 
-GENE_TEXT         = 
-
-TRANSCRIPT_PARAM  = 
-TRANSCRIPT_TEXT   = 
-
-SEARCH_TEXT       = 

--- a/conf/json/homo_sapiens_gca009914755v4_vcf.json
+++ b/conf/json/homo_sapiens_gca009914755v4_vcf.json
@@ -9,7 +9,7 @@
       "use_as_source" : 1,
       "use_seq_region_synonyms": 0,
       "use_vcf_consequences": 1,
-      "filename_template" : "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca009914755v4/T2T-CHM13v2.0/variation/Homo_sapiens-GCA_009914755.4-2022_08-gnomad.vcf.gz",
+      "filename_template" : "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca009914755v4/T2T-CHM13v2.0/variation/Homo_sapiens-GCA_009914755.4-2022_10-gnomad.vcf.gz",
       "population_prefix": "gnomADg:",
       "population_display_group": {
         "display_group_name": "gnomAD genomes v3.1.2",
@@ -72,7 +72,7 @@
       "use_as_source" : 1,
       "use_seq_region_synonyms": 0,
       "use_vcf_consequences": 1,
-      "filename_template" : "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca009914755v4/T2T-CHM13v2.0/variation/Homo_sapiens-GCA_009914755.4-2022_08-clinvar.vcf.gz"
+      "filename_template" : "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca009914755v4/T2T-CHM13v2.0/variation/Homo_sapiens-GCA_009914755.4-2022_10-clinvar.vcf.gz"
    }
       
   ]

--- a/conf/json/homo_sapiens_gca018466835v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018466835v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018466835.1",
+            "assembly": "HG02257.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018466835v1/HG02257.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018466835.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018466835.1",
+            "assembly": "HG02257.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018466835v1/HG02257.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018466835.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018466845v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018466845v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018466845.1",
+            "assembly": "HG02257.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018466845v1/HG02257.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018466845.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018466845.1",
+            "assembly": "HG02257.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018466845v1/HG02257.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018466845.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018466855v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018466855v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018466855.1",
+            "assembly": "HG02559.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018466855v1/HG02559.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018466855.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018466855.1",
+            "assembly": "HG02559.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018466855v1/HG02559.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018466855.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018466985v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018466985v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018466985.1",
+            "assembly": "HG02559.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018466985v1/HG02559.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018466985.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018466985.1",
+            "assembly": "HG02559.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018466985v1/HG02559.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018466985.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018467005v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018467005v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018467005.1",
+            "assembly": "HG02486.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018467005v1/HG02486.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018467005.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018467005.1",
+            "assembly": "HG02486.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018467005v1/HG02486.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018467005.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018467015v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018467015v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018467015.1",
+            "assembly": "HG02486.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018467015v1/HG02486.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018467015.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018467015.1",
+            "assembly": "HG02486.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018467015v1/HG02486.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018467015.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018467155v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018467155v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018467155.1",
+            "assembly": "HG01891.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018467155v1/HG01891.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018467155.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018467155.1",
+            "assembly": "HG01891.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018467155v1/HG01891.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018467155.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018467165v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018467165v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018467165.1",
+            "assembly": "HG01891.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018467165v1/HG01891.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018467165.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018467165.1",
+            "assembly": "HG01891.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018467165v1/HG01891.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018467165.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469405v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469405v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469405.1",
+            "assembly": "HG01258.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469405v1/HG01258.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469405.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469405.1",
+            "assembly": "HG01258.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469405v1/HG01258.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469405.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469415v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469415v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469415.1",
+            "assembly": "HG03516.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469415v1/HG03516.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018469415.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469415.1",
+            "assembly": "HG03516.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469415v1/HG03516.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018469415.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469425v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469425v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469425.1",
+            "assembly": "HG03516.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469425v1/HG03516.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469425.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469425.1",
+            "assembly": "HG03516.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469425v1/HG03516.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469425.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469665v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469665v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469665.1",
+            "assembly": "HG01123.pri.mat.f1_v2.1",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469665v1/HG01123.pri.mat.f1_v2.1/variation/Homo_sapiens-GCA_018469665.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469665.1",
+            "assembly": "HG01123.pri.mat.f1_v2.1",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469665v1/HG01123.pri.mat.f1_v2.1/variation/Homo_sapiens-GCA_018469665.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469675v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469675v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469675.1",
+            "assembly": "HG01258.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469675v1/HG01258.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018469675.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469675.1",
+            "assembly": "HG01258.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469675v1/HG01258.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018469675.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469685v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469685v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469685.1",
+            "assembly": "HG01361.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469685v1/HG01361.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469685.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469685.1",
+            "assembly": "HG01361.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469685v1/HG01361.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469685.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469695v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469695v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469695.1",
+            "assembly": "HG01123.alt.pat.f1_v2.1",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469695v1/HG01123.alt.pat.f1_v2.1/variation/Homo_sapiens-GCA_018469695.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469695.1",
+            "assembly": "HG01123.alt.pat.f1_v2.1",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469695v1/HG01123.alt.pat.f1_v2.1/variation/Homo_sapiens-GCA_018469695.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469705v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469705v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469705.1",
+            "assembly": "HG01361.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469705v1/HG01361.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018469705.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469705.1",
+            "assembly": "HG01361.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469705v1/HG01361.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018469705.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469865v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469865v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469865.1",
+            "assembly": "HG01358.pri.mat.f1_v2.1",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469865v1/HG01358.pri.mat.f1_v2.1/variation/Homo_sapiens-GCA_018469865.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469865.1",
+            "assembly": "HG01358.pri.mat.f1_v2.1",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469865v1/HG01358.pri.mat.f1_v2.1/variation/Homo_sapiens-GCA_018469865.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469875v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469875v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469875.1",
+            "assembly": "HG02622.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469875v1/HG02622.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469875.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469875.1",
+            "assembly": "HG02622.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469875v1/HG02622.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469875.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469925v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469925v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469925.1",
+            "assembly": "HG02622.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469925v1/HG02622.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018469925.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469925.1",
+            "assembly": "HG02622.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469925v1/HG02622.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018469925.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469935v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469935v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469935.1",
+            "assembly": "HG02717.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469935v1/HG02717.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469935.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469935.1",
+            "assembly": "HG02717.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469935v1/HG02717.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469935.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469945v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469945v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469945.1",
+            "assembly": "HG02630.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469945v1/HG02630.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018469945.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469945.1",
+            "assembly": "HG02630.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469945v1/HG02630.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018469945.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469955v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469955v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469955.1",
+            "assembly": "HG02630.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469955v1/HG02630.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469955.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469955.1",
+            "assembly": "HG02630.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469955v1/HG02630.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018469955.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018469965v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018469965v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018469965.1",
+            "assembly": "HG01358.alt.pat.f1_v2.1",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469965v1/HG01358.alt.pat.f1_v2.1/variation/Homo_sapiens-GCA_018469965.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018469965.1",
+            "assembly": "HG01358.alt.pat.f1_v2.1",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018469965v1/HG01358.alt.pat.f1_v2.1/variation/Homo_sapiens-GCA_018469965.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018470425v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018470425v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018470425.1",
+            "assembly": "HG02717.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018470425v1/HG02717.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018470425.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018470425.1",
+            "assembly": "HG02717.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018470425v1/HG02717.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018470425.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018470435v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018470435v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018470435.1",
+            "assembly": "HG02572.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018470435v1/HG02572.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018470435.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018470435.1",
+            "assembly": "HG02572.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018470435v1/HG02572.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018470435.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018470445v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018470445v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018470445.1",
+            "assembly": "HG02572.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018470445v1/HG02572.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018470445.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018470445.1",
+            "assembly": "HG02572.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018470445v1/HG02572.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018470445.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018470455v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018470455v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018470455.1",
+            "assembly": "HG02886.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018470455v1/HG02886.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018470455.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018470455.1",
+            "assembly": "HG02886.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018470455v1/HG02886.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018470455.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018470465v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018470465v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018470465.1",
+            "assembly": "HG02886.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018470465v1/HG02886.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018470465.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018470465.1",
+            "assembly": "HG02886.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018470465v1/HG02886.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018470465.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018471065v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018471065v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018471065.1",
+            "assembly": "HG01175.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471065v1/HG01175.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018471065.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018471065.1",
+            "assembly": "HG01175.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471065v1/HG01175.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018471065.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018471075v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018471075v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018471075.1",
+            "assembly": "HG01106.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471075v1/HG01106.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018471075.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018471075.1",
+            "assembly": "HG01106.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471075v1/HG01106.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018471075.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018471085v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018471085v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018471085.1",
+            "assembly": "HG01175.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471085v1/HG01175.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471085.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018471085.1",
+            "assembly": "HG01175.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471085v1/HG01175.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471085.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018471095v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018471095v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018471095.1",
+            "assembly": "HG00741.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471095v1/HG00741.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471095.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018471095.1",
+            "assembly": "HG00741.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471095v1/HG00741.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471095.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018471105v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018471105v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018471105.1",
+            "assembly": "HG00741.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471105v1/HG00741.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018471105.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018471105.1",
+            "assembly": "HG00741.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471105v1/HG00741.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018471105.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018471345v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018471345v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018471345.1",
+            "assembly": "HG01106.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471345v1/HG01106.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471345.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018471345.1",
+            "assembly": "HG01106.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471345v1/HG01106.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471345.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018471515v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018471515v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018471515.1",
+            "assembly": "HG00438.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471515v1/HG00438.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471515.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018471515.1",
+            "assembly": "HG00438.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471515v1/HG00438.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471515.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018471525v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018471525v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018471525.1",
+            "assembly": "HG02148.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471525v1/HG02148.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018471525.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018471525.1",
+            "assembly": "HG02148.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471525v1/HG02148.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018471525.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018471535v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018471535v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018471535.1",
+            "assembly": "HG02148.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471535v1/HG02148.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471535.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018471535.1",
+            "assembly": "HG02148.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471535v1/HG02148.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471535.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018471545v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018471545v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018471545.1",
+            "assembly": "HG01952.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471545v1/HG01952.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471545.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018471545.1",
+            "assembly": "HG01952.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471545v1/HG01952.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018471545.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018471555v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018471555v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018471555.1",
+            "assembly": "HG01952.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471555v1/HG01952.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018471555.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018471555.1",
+            "assembly": "HG01952.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018471555v1/HG01952.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018471555.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472565v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472565v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472565.1",
+            "assembly": "HG00673.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472565v1/HG00673.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472565.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472565.1",
+            "assembly": "HG00673.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472565v1/HG00673.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472565.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472575v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472575v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472575.1",
+            "assembly": "HG00621.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472575v1/HG00621.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472575.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472575.1",
+            "assembly": "HG00621.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472575v1/HG00621.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472575.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472585v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472585v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472585.1",
+            "assembly": "HG00673.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472585v1/HG00673.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472585.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472585.1",
+            "assembly": "HG00673.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472585v1/HG00673.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472585.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472595v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472595v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472595.1",
+            "assembly": "HG00438.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472595v1/HG00438.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472595.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472595.1",
+            "assembly": "HG00438.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472595v1/HG00438.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472595.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472605v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472605v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472605.1",
+            "assembly": "HG00621.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472605v1/HG00621.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472605.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472605.1",
+            "assembly": "HG00621.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472605v1/HG00621.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472605.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472685v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472685v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472685.1",
+            "assembly": "HG01071.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472685v1/HG01071.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472685.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472685.1",
+            "assembly": "HG01071.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472685v1/HG01071.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472685.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472695v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472695v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472695.1",
+            "assembly": "HG01928.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472695v1/HG01928.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472695.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472695.1",
+            "assembly": "HG01928.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472695v1/HG01928.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472695.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472705v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472705v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472705.1",
+            "assembly": "HG01928.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472705v1/HG01928.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472705.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472705.1",
+            "assembly": "HG01928.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472705v1/HG01928.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472705.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472715v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472715v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472715.1",
+            "assembly": "HG00735.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472715v1/HG00735.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472715.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472715.1",
+            "assembly": "HG00735.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472715v1/HG00735.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472715.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472725v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472725v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472725.1",
+            "assembly": "HG01071.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472725v1/HG01071.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472725.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472725.1",
+            "assembly": "HG01071.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472725v1/HG01071.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472725.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472765v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472765v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472765.1",
+            "assembly": "HG00735.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472765v1/HG00735.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472765.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472765.1",
+            "assembly": "HG00735.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472765v1/HG00735.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472765.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472825v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472825v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472825.1",
+            "assembly": "HG03579.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472825v1/HG03579.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472825.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472825.1",
+            "assembly": "HG03579.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472825v1/HG03579.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472825.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472835v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472835v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472835.1",
+            "assembly": "HG03579.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472835v1/HG03579.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472835.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472835.1",
+            "assembly": "HG03579.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472835v1/HG03579.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472835.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472845v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472845v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472845.1",
+            "assembly": "HG01978.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472845v1/HG01978.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472845.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472845.1",
+            "assembly": "HG01978.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472845v1/HG01978.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018472845.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472855v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472855v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472855.1",
+            "assembly": "HG03453.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472855v1/HG03453.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472855.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472855.1",
+            "assembly": "HG03453.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472855v1/HG03453.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472855.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018472865v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018472865v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018472865.1",
+            "assembly": "HG01978.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472865v1/HG01978.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472865.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018472865.1",
+            "assembly": "HG01978.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018472865v1/HG01978.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018472865.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018473295v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018473295v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018473295.1",
+            "assembly": "HG03540.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018473295v1/HG03540.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018473295.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018473295.1",
+            "assembly": "HG03540.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018473295v1/HG03540.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018473295.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018473305v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018473305v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018473305.1",
+            "assembly": "HG03453.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018473305v1/HG03453.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018473305.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018473305.1",
+            "assembly": "HG03453.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018473305v1/HG03453.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018473305.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018473315v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018473315v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018473315.1",
+            "assembly": "HG03540.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018473315v1/HG03540.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018473315.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018473315.1",
+            "assembly": "HG03540.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018473315v1/HG03540.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018473315.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018503245v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018503245v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018503245.1",
+            "assembly": "HG03486.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503245v1/HG03486.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018503245.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018503245.1",
+            "assembly": "HG03486.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503245v1/HG03486.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018503245.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018503255v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018503255v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018503255.1",
+            "assembly": "NA18906.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503255v1/NA18906.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018503255.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018503255.1",
+            "assembly": "NA18906.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503255v1/NA18906.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018503255.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018503285v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018503285v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018503285.1",
+            "assembly": "NA18906.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503285v1/NA18906.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018503285.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018503285.1",
+            "assembly": "NA18906.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503285v1/NA18906.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018503285.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018503525v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018503525v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018503525.1",
+            "assembly": "HG03486.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503525v1/HG03486.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018503525.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018503525.1",
+            "assembly": "HG03486.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503525v1/HG03486.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018503525.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018503575v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018503575v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018503575.1",
+            "assembly": "HG02818.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503575v1/HG02818.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018503575.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018503575.1",
+            "assembly": "HG02818.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503575v1/HG02818.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018503575.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018503585v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018503585v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018503585.1",
+            "assembly": "HG02818.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503585v1/HG02818.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018503585.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018503585.1",
+            "assembly": "HG02818.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018503585v1/HG02818.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018503585.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504045v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504045v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504045.1",
+            "assembly": "HG01243.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504045v1/HG01243.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504045.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504045.1",
+            "assembly": "HG01243.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504045v1/HG01243.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504045.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504055v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504055v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504055.1",
+            "assembly": "HG02080.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504055v1/HG02080.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504055.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504055.1",
+            "assembly": "HG02080.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504055v1/HG02080.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504055.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504065v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504065v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504065.1",
+            "assembly": "HG02723.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504065v1/HG02723.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504065.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504065.1",
+            "assembly": "HG02723.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504065v1/HG02723.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504065.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504075v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504075v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504075.1",
+            "assembly": "HG02723.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504075v1/HG02723.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504075.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504075.1",
+            "assembly": "HG02723.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504075v1/HG02723.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504075.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504085v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504085v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504085.1",
+            "assembly": "HG02080.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504085v1/HG02080.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504085.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504085.1",
+            "assembly": "HG02080.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504085v1/HG02080.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504085.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504365v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504365v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504365.1",
+            "assembly": "HG01109.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504365v1/HG01109.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504365.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504365.1",
+            "assembly": "HG01109.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504365v1/HG01109.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504365.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504375v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504375v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504375.1",
+            "assembly": "HG01243.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504375v1/HG01243.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504375.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504375.1",
+            "assembly": "HG01243.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504375v1/HG01243.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504375.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504625v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504625v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504625.1",
+            "assembly": "NA20129.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504625v1/NA20129.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504625.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504625.1",
+            "assembly": "NA20129.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504625v1/NA20129.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504625.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504635v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504635v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504635.1",
+            "assembly": "NA20129.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504635v1/NA20129.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504635.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504635.1",
+            "assembly": "NA20129.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504635v1/NA20129.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504635.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504645v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504645v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504645.1",
+            "assembly": "HG01109.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504645v1/HG01109.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504645.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504645.1",
+            "assembly": "HG01109.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504645v1/HG01109.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504645.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504655v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504655v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504655.1",
+            "assembly": "NA21309.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504655v1/NA21309.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504655.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504655.1",
+            "assembly": "NA21309.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504655v1/NA21309.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018504655.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018504665v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018504665v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018504665.1",
+            "assembly": "NA21309.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504665v1/NA21309.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504665.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018504665.1",
+            "assembly": "NA21309.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018504665v1/NA21309.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018504665.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018505825v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018505825v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018505825.1",
+            "assembly": "HG02109.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018505825v1/HG02109.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018505825.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018505825.1",
+            "assembly": "HG02109.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018505825v1/HG02109.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018505825.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018505835v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018505835v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018505835.1",
+            "assembly": "HG03492.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018505835v1/HG03492.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018505835.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018505835.1",
+            "assembly": "HG03492.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018505835v1/HG03492.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018505835.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018505845v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018505845v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018505845.1",
+            "assembly": "HG03492.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018505845v1/HG03492.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018505845.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018505845.1",
+            "assembly": "HG03492.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018505845v1/HG03492.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018505845.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018505855v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018505855v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018505855.1",
+            "assembly": "HG02055.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018505855v1/HG02055.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018505855.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018505855.1",
+            "assembly": "HG02055.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018505855v1/HG02055.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018505855.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018505865v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018505865v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018505865.1",
+            "assembly": "HG02109.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018505865v1/HG02109.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018505865.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018505865.1",
+            "assembly": "HG02109.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018505865v1/HG02109.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018505865.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018506125v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018506125v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018506125.1",
+            "assembly": "HG02055.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018506125v1/HG02055.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018506125.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018506125.1",
+            "assembly": "HG02055.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018506125v1/HG02055.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018506125.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018506155v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018506155v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018506155.1",
+            "assembly": "HG03098.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018506155v1/HG03098.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018506155.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018506155.1",
+            "assembly": "HG03098.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018506155v1/HG03098.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018506155.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018506165v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018506165v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018506165.1",
+            "assembly": "HG03098.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018506165v1/HG03098.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018506165.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018506165.1",
+            "assembly": "HG03098.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018506165v1/HG03098.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018506165.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018506955v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018506955v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018506955.1",
+            "assembly": "HG00733.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018506955v1/HG00733.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018506955.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018506955.1",
+            "assembly": "HG00733.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018506955v1/HG00733.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018506955.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018506975v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018506975v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018506975.1",
+            "assembly": "HG00733.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018506975v1/HG00733.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018506975.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018506975.1",
+            "assembly": "HG00733.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018506975v1/HG00733.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018506975.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018852585v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018852585v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018852585.1",
+            "assembly": "HG02145.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018852585v1/HG02145.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018852585.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018852585.1",
+            "assembly": "HG02145.pri.mat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018852585v1/HG02145.pri.mat.f1_v2/variation/Homo_sapiens-GCA_018852585.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/conf/json/homo_sapiens_gca018852595v1_vcf.json
+++ b/conf/json/homo_sapiens_gca018852595v1_vcf.json
@@ -1,0 +1,78 @@
+{
+    "collections": [
+        {
+            "id": "gnomADg",
+            "description": "Genome Aggregation Database genomes v3.1.2",
+            "species": "Homo_sapiens_GCA_018852595.1",
+            "assembly": "HG02145.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018852595v1/HG02145.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018852595.1-2022_10-gnomad.vcf.gz",
+            "population_prefix": "gnomADg:",
+            "population_display_group": {
+                "display_group_name": "gnomAD genomes v3.1.2",
+                "display_group_priority": 1.6
+            },
+            "populations": {
+                "9900028": {
+                    "name": "gnomADg:ALL",
+                    "_raw_name": "",
+                    "description": "All gnomAD genomes individuals"
+                },
+                "9900029": {
+                    "name": "afr",
+                    "description": "African/African American"
+                },
+                "9900030": {
+                    "name": "ami",
+                    "description": "Amish"
+                },
+                "9900031": {
+                    "name": "amr",
+                    "description": "Latino/Admixed American"
+                },
+                "9900032": {
+                    "name": "asj",
+                    "description": "Ashkenazi Jewish"
+                },
+                "9900033": {
+                    "name": "eas",
+                    "description": "East Asian"
+                },
+                "9900034": {
+                    "name": "fin",
+                    "description": "Finnish"
+                },
+                "9900035": {
+                    "name": "nfe",
+                    "description": "Non-Finnish European"
+                },
+                "9900036": {
+                    "name": "sas",
+                    "description": "South Asian"
+                },
+                "9900037": {
+                    "name": "oth",
+                    "description": "Other"
+                },
+                "9900038": {
+                    "name": "mid",
+                    "description": "Middle Eastern"
+                }
+            }
+        },
+        {
+            "id": "ClinVar",
+            "description": "ClinVar",
+            "species": "Homo_sapiens_GCA_018852595.1",
+            "assembly": "HG02145.alt.pat.f1_v2",
+            "type": "local",
+            "use_as_source": 1,
+            "use_seq_region_synonyms": 0,
+            "use_vcf_consequences": 1,
+            "filename_template": "/nfs/public/release/ensweb-data/data_files/rapid/homo_sapiens_gca018852595v1/HG02145.alt.pat.f1_v2/variation/Homo_sapiens-GCA_018852595.1-2022_10-clinvar.vcf.gz"
+        }
+    ]
+}

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -57,7 +57,7 @@ and the current and planned features.</p>
             for selected clades, available to download from our FTP site</li>
         </ul>
         <h2> Variation </h2>
-	<p> <a href="info/genome/variation/index.html">Variation data</a> is displayed for the <a href="Homo_sapiens_GCA_009914755.4/Info/Index">human T2T-CHM13v2.0</a> and <a href="Drosophila_melanogaster_GCA_000001215.4/Info/Index">Drosophila melanogaster (GCA_000001215.4)</a> assemblies</p>	
+	<p> <a href="info/genome/variation/index.html">Variation data</a> is displayed for the human pangenome and <a href="Drosophila_melanogaster_GCA_000001215.4/Info/Index">Drosophila melanogaster (GCA_000001215.4)</a> assemblies</p>	
       </div>
     </div>
   </div>

--- a/htdocs/info/genome/variation/index.html
+++ b/htdocs/info/genome/variation/index.html
@@ -7,10 +7,10 @@
 
 <h1>An overview of variant annotation</h1>
 
-<h2> Human Pangenome T2T-CHM13v2.0 (GCA_009914755.4) </h2>
+<h2> Human Pangenome </h2>
   <ul>
-    <li> We display variation data from gnomAD Genomes v3.1.2 and ClinVar 2022-07-09 (lifted over from GRCh38 using crossmap and the <a href="https://github.com/marbl/CHM13">chain file</a> in the T2T-CHM13v2.0 genome browser. Both variant sets can be downloaded via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/variation/2022_10/vcf">FTP</a> in VCFs, with molecular consequences predicted by Ensembl VEP </li>
-    <li> Additionally, we have generated an Ensembl VEP cache containing the remapped Ensembl/GENCODE gene set for T2T-CHM13v2.0 to facilitate analysing your own variant data with Ensembl VEP. This is also available via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/variation/2022_10/indexed_vep_cache">FTP</a>. The gnomAD and ClinVar data described above can be used in VEP analysis using the <a href="http://www.ensembl.org/info/docs/tools/vep/script/vep_custom.html">custom annotations</a> option.
+    <li> We display variation data from gnomAD Genomes v3.1.2 and ClinVar 2022-07-09 (lifted over from GRCh38 using crossmap and the <a href="https://github.com/marbl/CHM13">chain file</a> in the genome browser. Both variant sets can be downloaded via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/variation/2022_10/vcf">FTP</a> in VCFs, with molecular consequences predicted by Ensembl VEP </li>
+    <li> Additionally, we have generated an Ensembl VEP cache containing the remapped Ensembl/GENCODE gene set to facilitate analysing your own variant data with Ensembl VEP. This is also available via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/variation/2022_10/indexed_vep_cache">FTP</a>. The gnomAD and ClinVar data described above can be used in VEP analysis using the <a href="http://www.ensembl.org/info/docs/tools/vep/script/vep_custom.html">custom annotations</a> option.
   </ul>
 <h2> Drosophila melanogatser (GCA_000001215.4) </h2>
   <ul> 

--- a/htdocs/info/genome/variation/index.html
+++ b/htdocs/info/genome/variation/index.html
@@ -9,8 +9,8 @@
 
 <h2> Human Pangenome T2T-CHM13v2.0 (GCA_009914755.4) </h2>
   <ul>
-    <li> We display variation data from gnomAD Genomes v3.1.2 and ClinVar 2022-07-09 (lifted over from GRCh38 using crossmap and the <a href="https://github.com/marbl/CHM13">chain file</a> in the T2T-CHM13v2.0 genome browser. Both variant sets can be downloaded via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/variation/2022_08/vcf">FTP</a> in VCFs, with molecular consequences predicted by Ensembl VEP </li>
-    <li> Additionally, we have generated an Ensembl VEP cache containing the remapped Ensembl/GENCODE gene set for T2T-CHM13v2.0 to facilitate analysing your own variant data with Ensembl VEP. This is also available via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/variation/2022_08/indexed_vep_cache">FTP</a>. The gnomAD and ClinVar data described above can be used in VEP analysis using the <a href="http://www.ensembl.org/info/docs/tools/vep/script/vep_custom.html">custom annotations</a> option.
+    <li> We display variation data from gnomAD Genomes v3.1.2 and ClinVar 2022-07-09 (lifted over from GRCh38 using crossmap and the <a href="https://github.com/marbl/CHM13">chain file</a> in the T2T-CHM13v2.0 genome browser. Both variant sets can be downloaded via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/variation/2022_10/vcf">FTP</a> in VCFs, with molecular consequences predicted by Ensembl VEP </li>
+    <li> Additionally, we have generated an Ensembl VEP cache containing the remapped Ensembl/GENCODE gene set for T2T-CHM13v2.0 to facilitate analysing your own variant data with Ensembl VEP. This is also available via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/variation/2022_10/indexed_vep_cache">FTP</a>. The gnomAD and ClinVar data described above can be used in VEP analysis using the <a href="http://www.ensembl.org/info/docs/tools/vep/script/vep_custom.html">custom annotations</a> option.
   </ul>
 <h2> Drosophila melanogatser (GCA_000001215.4) </h2>
   <ul> 


### PR DESCRIPTION
This PR adds json and ini-files to RR-39

Tested on sandbox:
Track: http://wp-np2-25.ebi.ac.uk:6080/Homo_sapiens_GCA_018466835.1/Location/View?r=JAGYVI010000001.1:213530-366224;db=core;mr=JAGYVI010000003.1:1179057-1214704
Variant table: http://wp-np2-25.ebi.ac.uk:6080/Homo_sapiens_GCA_018466835.1/Location/Variant/Table?db=core;r=JAGYVI010000001.1:213530-213610;mr=JAGYVI010000003.1:1179057-1214704