### PR TITLE
Update species name and doc

### DIFF
--- a/conf/json/drosophila_melanogaster_vcf.json
+++ b/conf/json/drosophila_melanogaster_vcf.json
@@ -3,7 +3,7 @@
         {
             "id": "eva_drosophila_melanogaster_gca000001215v4",
             "description": "Variants from EVA",
-            "species": "Drosophila_melanogaster_GCA_000001215.4",
+            "species": "Drosophila_melanogaster",
             "assembly": "BDGP6.32",
             "type": "remote",
             "filename_template": "https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_3/by_species/drosophila_melanogaster/GCA_000001215.4/GCA_000001215.4_current_ids.vcf.gz",

--- a/htdocs/info/genome/variation/index.html
+++ b/htdocs/info/genome/variation/index.html
@@ -9,8 +9,8 @@
 
 <h2> Human Pangenome </h2>
   <ul>
-    <li> We display variation data from gnomAD Genomes v3.1.2 and ClinVar 2022-07-09 (lifted over from GRCh38 using crossmap and the <a href="https://github.com/marbl/CHM13">chain file</a> in the genome browser. Both variant sets can be downloaded via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/variation/2022_10/vcf">FTP</a> in VCFs, with molecular consequences predicted by Ensembl VEP </li>
-    <li> Additionally, we have generated an Ensembl VEP cache containing the remapped Ensembl/GENCODE gene set to facilitate analysing your own variant data with Ensembl VEP. This is also available via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/variation/2022_10/indexed_vep_cache">FTP</a>. The gnomAD and ClinVar data described above can be used in VEP analysis using the <a href="http://www.ensembl.org/info/docs/tools/vep/script/vep_custom.html">custom annotations</a> option.
+    <li> We display variation data from gnomAD Genomes v3.1.2 and ClinVar 2022-07-09 (lifted over from GRCh38 using crossmap and the <a href="https://github.com/marbl/CHM13">chain file</a> in the genome browser. Both variant sets can be downloaded via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/ensembl/variation/2022_10/vcf">FTP</a> in VCFs, with molecular consequences predicted by Ensembl VEP </li>
+    <li> Additionally, we have generated an Ensembl VEP cache containing the remapped Ensembl/GENCODE gene set to facilitate analysing your own variant data with Ensembl VEP. This is also available via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/ensembl/variation/2022_10/indexed_vep_cache">FTP</a>. The gnomAD and ClinVar data described above can be used in VEP analysis using the <a href="http://www.ensembl.org/info/docs/tools/vep/script/vep_custom.html">custom annotations</a> option.
   </ul>
 <h2> Drosophila melanogatser (GCA_000001215.4) </h2>
   <ul> 


### PR DESCRIPTION
d.mel core db already have species.url updated `species.url` name - 
`Drosophila_melanogaster_GCA_000001215.4` --> `Drosophila_melanogaster`

The variant is not showing in the tracks for that reason - 
https://rapid.ensembl.org/Drosophila_melanogaster/Location/View?r=2L%3A8430000-8440000

sandbox link to test:
http://wp-np2-11.ebi.ac.uk:7070/Drosophila_melanogaster/Variation/Explore?r=2L:8435462-8436462;v=rs202610707;vdb=variation;vf=2L:8435962:C_T:EVA