### PR TITLE
Fix species page link

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -57,7 +57,7 @@ and the current and planned features.</p>
             for selected clades, available to download from our FTP site</li>
         </ul>
         <h2> Variation </h2>
-	<p> <a href="info/genome/variation/index.html">Variation data</a> is displayed for the human pangenome, <a href="Drosophila_melanogaster_GCA_000001215.4/Info/Index">Drosophila melanogaster (GCA_000001215.4)</a>,
+	<p> <a href="info/genome/variation/index.html">Variation data</a> is displayed for the human pangenome, <a href="Drosophila_melanogaster/Info/Index">Drosophila melanogaster (GCA_000001215.4)</a>,
     and <a href="Cajanus_cajan_GCA_000340665.1/Info/Index">Cajanus cajan (GCA_000340665.1)</a> assemblies</p>	
          <div class="no-top-margin">
       <a href="https://globalbiodata.org/scientific-activities/global-core-biodata-resources"><img src="/img/GCBR-Logo-RGB.svg" alt="Global Bio Data logo" style="width:100px;height:73px" class="float-right"/></a>


### PR DESCRIPTION
Drosophila species page link was incorrect in the landing page for rr-41 live site. 
Change tested in sandbox - http://wp-np2-11.ebi.ac.uk:7070/index.html 