### PR TITLE
Update variant annotation info page

### DIFF
--- a/htdocs/info/genome/variation/index.html
+++ b/htdocs/info/genome/variation/index.html
@@ -10,7 +10,19 @@
 <h2> Human Pangenome </h2>
   <ul>
     <li> We display variation data from gnomAD Genomes v3.1.2 and ClinVar 2022-07-09 (lifted over from GRCh38 using crossmap and the <a href="https://github.com/marbl/CHM13">chain file</a> in the genome browser. Both variant sets can be downloaded via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/ensembl/variation/2022_10/vcf">FTP</a> in VCFs, with molecular consequences predicted by Ensembl VEP </li>
-    <li> Additionally, we have generated an Ensembl VEP cache containing the remapped Ensembl/GENCODE gene set to facilitate analysing your own variant data with Ensembl VEP. This is also available via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/ensembl/variation/2022_10/indexed_vep_cache">FTP</a>. The gnomAD and ClinVar data described above can be used in VEP analysis using the <a href="http://www.ensembl.org/info/docs/tools/vep/script/vep_custom.html">custom annotations</a> option.
+    <li> Additionally, we have generated an Ensembl VEP cache containing the remapped Ensembl/GENCODE gene set to facilitate analysing your own variant data with Ensembl VEP. This is also available via the <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/ensembl/variation/2022_10/indexed_vep_cache">FTP</a>. The gnomAD and ClinVar data described above can be used in VEP analysis using the <a href="http://www.ensembl.org/info/docs/tools/vep/script/vep_custom.html">custom annotations</a> option </li>
+  </ul>
+<h2> Human T2T-CHM13v2.0 (GCA_009914755.4) </h2>
+  <ul>
+    <li> For the T2T-CHM13v2.0 genome assembly we display the following tracks produced by our colleagues in the Telomere to Telomere (T2T) consortium, with added molecular consequences predicted by Ensembl VEP, in addition to tracks for gnomAD and ClinVar: </li>
+      <ul>
+        <li> dbSNP build 155 (lifted over) </li>
+        <li> NHGRI-EBI GWAS catalog (lifted over) </li>
+        <li> 1000 Genomes Phase 3 (recalled on CHM13) </li>
+        <li> Simons Genome Diversity Project (recalled on CHM13) </li>
+      </ul>
+    </li>
+    <li> The annotated VCFs are all available from our <a href="https://ftp.ensembl.org/pub/rapid-release/species/Homo_sapiens/GCA_009914755.4/ensembl/variation/2022_10/vcf/">FTP</a> </li> 
   </ul>
 <h2> Drosophila melanogatser (GCA_000001215.4) </h2>
   <ul> 


### PR DESCRIPTION
Update variant annotation info page
Static HTML changes

sandbox link with changes: [http://wp-np2-25.ebi.ac.uk:8003/info/genome/variation/index.html](http://wp-np2-25.ebi.ac.uk:8003/info/genome/variation/index.html)


@jamie-m-a can review from Ensembl/Variation side